### PR TITLE
Fix linuxdeploy build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+*.AppImage*
+*.zsync
+squashfs-root/
+*build*/

--- a/Galaxy-Calculator.pro
+++ b/Galaxy-Calculator.pro
@@ -9,14 +9,6 @@ SOURCES += src/main.cpp src/tablemodel.cpp
 HEADERS += src/tablemodel.h
 
 RESOURCES += resources.qrc
-#
-# This did not change Qt not being installed in LinuxDeploy
-# QML_IMPORT_PATH = qml
-# QML_IMPORT_PATH = $$PWD/qml
-# this is for a Designer, I think that is ui, I do not have any
-# QML_DESIGNER_IMPORT_PATH will be used only in Qt Quick Designer
-QML_IMPORT_PATH =
-QML_DESIGNER_IMPORT_PATH =
 
 DEFINES += QT_DEPRECATED_WARNINGS
 

--- a/tools/build-with-qmake.sh
+++ b/tools/build-with-qmake.sh
@@ -2,28 +2,22 @@
 # Last Update: 17 April 2020
 # replace the ? in shell check
 # cd /mnt/qnap-light-wizzard/workspace/GalaticCalculator/Galaxy-Calculator/tools; shell?check -x build-with-qmake.sh
-ls; 
-set -x;
-set -e;
-# Set the OUTPUT name for AppImage to be the same as the BIN_PRO_RES_NAME
-export OUTPUT="${BIN_PRO_RES_NAME}.AppImage";
-# AppImageUpdate Informatoin
-export VERBOSE=1;
-export UPDATE_INFORMATION="gh-releases-zsync|${GITHUB_USERNAME}|${GITHUB_PROJECT}|continuous|${BIN_PRO_RES_NAME}-*x86_64.AppImage.zsync";
-echo "UPDATE_INFORMATION=$UPDATE_INFORMATION";
-#export UPDATE_INFORMATION="zsync|https://github.com/${GITHUB_USERNAME}/${GITHUB_PROJECT}/releases/download/continuous/${BIN_PRO_RES_NAME}-x86_64.AppImage.zsync";
-# building in temporary directory to keep system clean
+
+set -x
+set -e
+
 # use RAM disk if possible (as in: not building on CI system like Travis, and RAM disk is available)
 if [ "$CI" == "" ] && [ -d "/dev/shm" ]; then
     TEMP_BASE="/dev/shm";
 else
     TEMP_BASE="/tmp";
 fi
-# Make Build Directory
-BUILD_DIR="$(mktemp -d -p "$TEMP_BASE" "${BIN_PRO_RES_NAME}-build-XXXXXX")";
+
+# building in temporary directory to keep system clean
+BUILD_DIR=$(mktemp -d -p "$TEMP_BASE" "${BIN_PRO_RES_NAME}-build-XXXXXX")
 
 # make sure to clean up build dir, even if errors occur
-function cleanup() 
+function cleanup()
 {
     if [ -d "$BUILD_DIR" ]; then
         rm -rf "$BUILD_DIR"
@@ -32,114 +26,58 @@ function cleanup()
 trap cleanup EXIT
 
 # store repo root as variable
-REPO_ROOT="$(readlink -f "$(dirname "$(dirname "$0")")")";
-OLD_CWD="$(readlink -f .)";
+REPO_ROOT=$(readlink -f "$(dirname "$(dirname "$0")")")
+OLD_CWD=$(readlink -f .)
 
-echo "REPO_ROOT=$REPO_ROOT";
-echo "OLD_CWD=$OLD_CWD";
 # switch to build dir
-pushd "$BUILD_DIR";
+pushd "$BUILD_DIR"
 
 # configure build files with qmake
-# we need to explicitly set the install prefix, as CMake's default is /usr/local for some reason...
-#qmake -makefile "${REPO_ROOT}/${BIN_PRO_RES_NAME}.pro";
-qmake -makefile "${REPO_ROOT}";
+qmake -makefile "${REPO_ROOT}"
 
 # build project and install files into AppDir
-make -j"$(nproc)";
-make install INSTALL_ROOT="AppDir";
+make -j"$(nproc)"
+make install INSTALL_ROOT="AppDir"
+
+# now, build AppImage using linuxdeploy and linuxdeploy-plugin-qt
+# download linuxdeploy and its Qt plugin
+wget -c -nv "https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage";
+wget -c -nv "https://github.com/linuxdeploy/linuxdeploy-plugin-qt/releases/download/continuous/linuxdeploy-plugin-qt-x86_64.AppImage";
+
+# make them executable
+chmod +x linuxdeploy*.AppImage;
+
+# AppImage update informatoin
+export UPDATE_INFORMATION="gh-releases-zsync|${GITHUB_USERNAME}|${GITHUB_PROJECT}|continuous|${BIN_PRO_RES_NAME}-*x86_64.AppImage.zsync";
+
 # make sure Qt plugin finds QML sources so it can deploy the imported files
-export QML_SOURCES_PATHS="${REPO_ROOT}/src";
-echo "QML_SOURCES_PATHS=${QML_SOURCES_PATHS}";
-echo "-d ${REPO_ROOT}/resources/${BIN_PRO_RES_NAME}.desktop";
-ls "${REPO_ROOT}/resources";
-ls;
-declare -i LINUX_DEPLOY_USING; LINUX_DEPLOY_USING=0;
-if [ "${LINUX_DEPLOY_USING}" -eq 0 ]; then
-    echo "Downloading LinuxDeploy AppImage and Qt Plugin";
-    # now, build AppImage using linuxdeploy and linuxdeploy-plugin-qt
-    # download linuxdeploy and its Qt plugin
-    wget -c -nv "https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage";
-    wget -c -nv "https://github.com/linuxdeploy/linuxdeploy-plugin-qt/releases/download/continuous/linuxdeploy-plugin-qt-x86_64.AppImage";
-    # make them executable
-    chmod +x linuxdeploy*.AppImage;
-    
-    # Tried this to figure out why I am getting "QtQuick" is not installed
-    #if [ -d "${TRAVIS_BUILD_DIR}/qml" ]; then
-    #    echo "Found ${TRAVIS_BUILD_DIR}/qml"
-    #    mkdir -p qml;
-    #    cp -rv "${TRAVIS_BUILD_DIR}/qml" "qml/";
-    #fi
-    
-    echo "Starting linuxdeploy-x86_64.AppImage";
-    # QtQuickApp does support "make install", but we don't use it because we want to show the manual packaging approach in this example
-    # initialize AppDir, bundle shared libraries, add desktop file and icon, use Qt plugin to bundle additional resources, and build AppImage, all in one command
-    ./linuxdeploy-x86_64.AppImage --appdir "AppDir" -e "${BIN_PRO_RES_NAME}" -i "${REPO_ROOT}/resources/${BIN_PRO_RES_NAME}.png" -d "${REPO_ROOT}/resources/${BIN_PRO_RES_NAME}.desktop" --plugin qt --output appimage;
-    echo "Finished linuxdeploy-x86_64.AppImage";
-fi
-# move built AppImage back into original CWD
-if [ -f "${BIN_PRO_RES_NAME}".AppImage ]; then
-    echo "Found ${BIN_PRO_RES_NAME}.AppImage"
-    chmod +x "${BIN_PRO_RES_NAME}.AppImage";
-    mv "${BIN_PRO_RES_NAME}.AppImage" "${OLD_CWD}";
-fi
-if [ -f "${BIN_PRO_RES_NAME}".AppImage.zsync ]; then
-    echo "Found ${BIN_PRO_RES_NAME}.AppImage.zsync"
-    chmod +x "${BIN_PRO_RES_NAME}.AppImage.zsync";
-    mv "${BIN_PRO_RES_NAME}.AppImage.zsync" "${OLD_CWD}";
-fi
-if [ -f "${BIN_PRO_RES_NAME}" ]; then
-    echo "Found ${BIN_PRO_RES_NAME}"
-    chmod +x "${BIN_PRO_RES_NAME}";
-    mv "${BIN_PRO_RES_NAME}" "${OLD_CWD}";
-fi
-popd;
-# I added this to troubleshoot why the above is not working, its not including Qt libraries
-LINUX_DEPLOY_USING=1;
-if [ "${LINUX_DEPLOY_USING}" -eq 1 ]; then
-    echo "Downloading LinuxDeployQt";
-    wget -c -nv "https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage";
-    chmod a+x "linuxdeployqt-continuous-x86_64.AppImage";
-    unset QTDIR; unset QT_PLUGIN_PATH ; unset LD_LIBRARY_PATH;
-    export VERSION="travis";
+export QML_SOURCES_PATHS="${REPO_ROOT}/qml"
 
-    if [ -f "${BIN_PRO_RES_NAME}" ]; then
-        echo "Found ${BIN_PRO_RES_NAME}"
-        ls "${TRAVIS_BUILD_DIR}/usr";
-        mkdir -p "${TRAVIS_BUILD_DIR}/usr/bin";
-        cp -pv "${BIN_PRO_RES_NAME}" "${TRAVIS_BUILD_DIR}/usr/bin";
-        ls "${TRAVIS_BUILD_DIR}/usr/bin";
-    fi
+# QtQuickApp does support "make install", but we don't use it because we want to show the manual packaging approach in this example
+# initialize AppDir, bundle shared libraries, add desktop file and icon, use Qt plugin to bundle additional resources, and build AppImage, all in one command
+./linuxdeploy-x86_64.AppImage --appdir "AppDir" -e "${BIN_PRO_RES_NAME}" -i "${REPO_ROOT}/resources/${BIN_PRO_RES_NAME}.png" -d "${REPO_ROOT}/resources/${BIN_PRO_RES_NAME}.desktop" --plugin qt --output appimage
 
-    echo "Starting linuxdeployqt-continuous-x86_64.AppImage";
-    ls;
-    echo "./linuxdeployqt-continuous-x86_64.AppImage ${TRAVIS_BUILD_DIR}/usr/share/applications/${BIN_PRO_RES_NAME}.desktop -extra-plugins=iconengines,imageformats -verbose=2 -qmldir=${TRAVIS_BUILD_DIR}/qml/ -appimage;";
-    ./linuxdeployqt-continuous-x86_64.AppImage "${TRAVIS_BUILD_DIR}/usr/share/applications/${BIN_PRO_RES_NAME}.desktop" -extra-plugins=iconengines,imageformats -verbose=2 -qmldir="${TRAVIS_BUILD_DIR}/qml/" -appimage;
-    echo "Finished linuxdeployqt-continuous-x86_64.AppImage"
-fi
+mv Galaxy*.AppImage* "$OLD_CWD"
 
-echo "Completed LinuxDeploy"
 
-ls;
-#
-echo "Running Qt Installer Framework";
+echo "Running Qt Installer Framework"
 
-mkdir -pv qtinstallerframework;
-7z e "${QIF_ARCHIVE}" -o./qtinstallerframework;
-ls;
-ls -lh qtinstallerframework/; 
-chmod -R +x ./qtinstallerframework;
-cp -v "${TRAVIS_BUILD_DIR}/${BIN_PRO_RES_NAME}.AppImage" "${QIF_PACKAGE_DATA}";
-cp -v "${TRAVIS_BUILD_DIR}/${BIN_PRO_RES_NAME}.AppImage.zsync" "${QIF_PACKAGE_DATA}";
-# cp -v "resources/Galaxy-Calculator.desktop" "${QIF_PACKAGE_DATA}";
-cp -v "${TRAVIS_BUILD_DIR}/resources/Galaxy-Calculator.png" "${QIF_PACKAGE_DATA}";
-cp -v "${TRAVIS_BUILD_DIR}/resources/Galaxy-Calculator.svg" "${QIF_PACKAGE_DATA}";
-cp -v "${TRAVIS_BUILD_DIR}/resources/Galaxy-Calculator.ico" "${QIF_PACKAGE_DATA}";
+mkdir -pv qtinstallerframework
+7z e "${QIF_ARCHIVE}" -o./qtinstallerframework
+ls
+ls -lh qtinstallerframework/ 
+chmod -R +x ./qtinstallerframework
+cp -v "${TRAVIS_BUILD_DIR}/${BIN_PRO_RES_NAME}.AppImage" "${QIF_PACKAGE_DATA}"
+cp -v "${TRAVIS_BUILD_DIR}/${BIN_PRO_RES_NAME}.AppImage.zsync" "${QIF_PACKAGE_DATA}"
+# cp -v "resources/Galaxy-Calculator.desktop" "${QIF_PACKAGE_DATA}"
+cp -v "${TRAVIS_BUILD_DIR}/resources/Galaxy-Calculator.png" "${QIF_PACKAGE_DATA}"
+cp -v "${TRAVIS_BUILD_DIR}/resources/Galaxy-Calculator.svg" "${QIF_PACKAGE_DATA}"
+cp -v "${TRAVIS_BUILD_DIR}/resources/Galaxy-Calculator.ico" "${QIF_PACKAGE_DATA}"
 
-rsync -Ravr "${TRAVIS_BUILD_DIR}/usr/share/icons" "${QIF_PACKAGE_DATA}/icons";
-ls "${QIF_PACKAGE_DATA}/icons";
+rsync -Ravr "${TRAVIS_BUILD_DIR}/usr/share/icons" "${QIF_PACKAGE_DATA}/icons"
+ls "${QIF_PACKAGE_DATA}/icons"
 
-echo "Running Qt Installer Framework";
+echo "Running Qt Installer Framework"
 # Note that this is only for building the Qt-IF file, it does not ship with this qtaccount.ini
 # These values can be found here:
 # Windows
@@ -152,11 +90,9 @@ echo "Running Qt Installer Framework";
 # "/Users/$USERNAME/Library/Application Support/Qt/qtlicenses.ini"
 # "/Users/$USERNAME/Library/Application Support/Qt/qtaccount.ini"
 # Not sure if this is working, it will work without it, but it can be useful for commercial use.
-if [ -n "${QT_EMAIL}" ]; then printf "[QtAccount]\nemail=%s\njwt=%s\nu=%s" "${QT_EMAIL}" "${QT_JWT}" "${QT_U}" > qtaccount.ini; fi;
-./qtinstallerframework/binarycreator -c "${TRAVIS_BUILD_DIR}/config/config.xml" -p "${TRAVIS_BUILD_DIR}/packages" "${ARTIFACT_QIF}";
+if [ -n "${QT_EMAIL}" ]; then printf "[QtAccount]\nemail=%s\njwt=%s\nu=%s" "${QT_EMAIL}" "${QT_JWT}" "${QT_U}" > qtaccount.ini; fi
+./qtinstallerframework/binarycreator -c "${TRAVIS_BUILD_DIR}/config/config.xml" -p "${TRAVIS_BUILD_DIR}/packages" "${ARTIFACT_QIF}"
 # remove this file now for security: Note that these Values are stored in Travis Environment Variables, and the credential part is encrypted to begin with
-if [ -n "${QT_EMAIL}" ]; then rm -fv qtaccount.ini; fi;
-ls;
-echo "Completed build-with-qmake.sh";
-################################ End of File ##################################
-
+if [ -n "${QT_EMAIL}" ]; then rm -fv qtaccount.ini; fi
+ls
+echo "Completed build-with-qmake.sh"


### PR DESCRIPTION
Removes most (debugging) hacks, simplifies scripts, fixes the QML path. See https://github.com/linuxdeploy/linuxdeploy/issues/128#issuecomment-615878556 for more information.

Please note you need to build against a fairly recent Qt. For AppImages, you should use Stephan Binner's [PPA](https://launchpad.net/~beineri/+archive/ubuntu/opt-qt-5.14.1-xenial). For more information on how to use packages from the PPA, see the PPA page, please. 